### PR TITLE
Fixed `remove` method to accept `nullptr` node.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ __pycache__/
 **/.idea/*
 !**/.idea/dictionaries
 !**/.idea/dictionaries/*
+
+# Dumb OS crap
+.DS_Store

--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -34,11 +34,11 @@
 /// be costly in terms of execution time.
 #ifndef CAVL_ASSERT
 #    if defined(CAVL_NO_ASSERT) && CAVL_NO_ASSERT
-#                                       // NOLINTNEXTLINE(cppcoreguidelines-macro-usage) function-like macro
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage) function-like macro
 #        define CAVL_ASSERT(x) (void) 0 /* NOSONAR cpp:S960 */
 #    else
 #        include <cassert>
-#                                        // NOLINTNEXTLINE(cppcoreguidelines-macro-usage) function-like macro
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage) function-like macro
 #        define CAVL_ASSERT(x) assert(x) /* NOSONAR cpp:S960 */
 #    endif
 #endif

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -1,22 +1,22 @@
 /// Copyright (c) 2021 Pavel Kirienko <pavel@uavcan.org>
 
 #include "cavl.hpp"
-#include <unity.h>
+
 #include <algorithm>
 #include <array>
-#include <cstdio>
 #include <cstdint>
+#include <cstdio>
 #include <cstdlib>
-#include <ctime>
-#include <string>
+#include <functional>
 #include <iostream>
-#include <sstream>
+#include <limits>
 #include <memory>
 #include <numeric>
-#include <limits>
-#include <vector>
+#include <sstream>
+#include <string>
 #include <type_traits>
-#include <functional>
+#include <unity.h>
+#include <vector>
 
 #if __cplusplus >= 201703L
 #    define NODISCARD [[nodiscard]]
@@ -679,6 +679,19 @@ void testManual(const std::function<N*(std::uint8_t)>& factory)
     TEST_ASSERT_EQUAL(t.at(4), static_cast<N*>(tr3));  // Moved.
     TEST_ASSERT_NULL(static_cast<N*>(tr2));            // NOLINT use after move is intentional.
     TEST_ASSERT_EQUAL(1, tr3.size());
+
+    // Try various methods on empty tree (including `const` one).
+    //
+    std::puts("REMOVE 4");
+    tr3.remove(t[4]);
+    tr3.remove(nullptr);
+    TEST_ASSERT_EQUAL(nullptr, tr3.min());
+    TEST_ASSERT_EQUAL(nullptr, tr3.max());
+    const TreeType tr4_const{std::move(tr3)};
+    TEST_ASSERT_EQUAL(0, tr4_const.size());
+    TEST_ASSERT_EQUAL(nullptr, tr4_const.min());
+    TEST_ASSERT_EQUAL(nullptr, tr4_const.max());
+    TEST_ASSERT_EQUAL(0, tr4_const.traverse([](const N&) { return 13; }));
 
     // Clean up manually to reduce boilerplate in the tests. This is super sloppy but OK for a basic test suite.
     for (auto* const x : t)

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -2,6 +2,8 @@
 
 #include "cavl.hpp"
 
+#include <unity.h>
+
 #include <algorithm>
 #include <array>
 #include <cstdint>
@@ -16,7 +18,6 @@
 #include <sstream>
 #include <string>
 #include <type_traits>
-#include <unity.h>
 #include <vector>
 
 #if __cplusplus >= 201703L

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstdlib>
+#include <ctime>
 #include <functional>
 #include <iostream>
 #include <limits>


### PR DESCRIPTION
Also:
- Clang-Tidy & Sonar fixes (identified during integration into libcyphal project).
- Increased coverage:
<img width="1129" alt="image" src="https://github.com/pavel-kirienko/cavl/assets/2915466/a5cdd384-4d5d-4a25-ac47-20b5cc967443">
