### PR TITLE
Support moving nodes and refactor to eliminate recursion

### DIFF
--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -172,191 +172,36 @@ protected:
     static auto traverse(Derived* const root, const Vis& visitor, const bool reverse = false)  //
         -> std::enable_if_t<!std::is_void<R>::value, R>
     {
-        Node* node = root;
-        Node* prev = nullptr;
-
-        while (nullptr != node)
-        {
-            Node* next = node->up;
-
-            if (prev == node->up)
-            {
-                // We came down to this node from `prev`.
-
-                if (auto* left = node->lr[reverse])
-                {
-                    next = left;
-                }
-                else
-                {
-                    if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
-                    {
-                        return t;
-                    }
-
-                    if (auto* right = node->lr[!reverse])
-                    {
-                        next = right;
-                    }
-                }
-            }
-            else if (prev == node->lr[reverse])
-            {
-                // We came up to this node from the left child.
-
-                if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
-                {
-                    return t;
-                }
-
-                if (auto* right = node->lr[!reverse])
-                {
-                    next = right;
-                }
-            }
-
-            prev = std::exchange(node, next);
-        }
-        return R{};
+        return inOrderTraverseImpl<R, Node>(root, visitor, reverse);
     }
     template <typename Vis>
-    static auto traverse(Derived* const root, const Vis& visitor, const bool reverse = false)
+    static auto traverse(Derived* const root, const Vis& visitor, const bool reverse = false)  //
         -> std::enable_if_t<std::is_void<invoke_result<Vis, Derived&>>::value>
     {
-        Node* node = root;
-        Node* prev = nullptr;
-
-        while (nullptr != node)
-        {
-            Node* next = node->up;
-
-            if (prev == node->up)
-            {
-                // We came down to this node from `prev`.
-
-                if (auto* left = node->lr[reverse])
-                {
-                    next = left;
-                }
-                else
-                {
-                    visitor(*down(node));
-
-                    if (auto* right = node->lr[!reverse])
-                    {
-                        next = right;
-                    }
-                }
-            }
-            else if (prev == node->lr[reverse])
-            {
-                // We came up to this node from the left child.
-
-                visitor(*down(node));
-
-                if (auto* right = node->lr[!reverse])
-                {
-                    next = right;
-                }
-            }
-
-            prev = std::exchange(node, next);
-        }
+        inOrderTraverseImpl<Node>(root, visitor, reverse);
     }
     template <typename Vis, typename R = invoke_result<Vis, const Derived&>>
     static auto traverse(const Derived* const root, const Vis& visitor, const bool reverse = false)  //
         -> std::enable_if_t<!std::is_void<R>::value, R>
     {
-        const Node* node = root;
-        const Node* prev = nullptr;
-
-        while (nullptr != node)
-        {
-            const Node* next = node->up;
-
-            if (prev == node->up)
-            {
-                // We came down to this node from `prev`.
-
-                if (auto* left = node->lr[reverse])
-                {
-                    next = left;
-                }
-                else
-                {
-                    if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
-                    {
-                        return t;
-                    }
-
-                    if (auto* right = node->lr[!reverse])
-                    {
-                        next = right;
-                    }
-                }
-            }
-            else if (prev == node->lr[reverse])
-            {
-                // We came up to this node from the left child.
-
-                if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
-                {
-                    return t;
-                }
-
-                if (auto* right = node->lr[!reverse])
-                {
-                    next = right;
-                }
-            }
-
-            prev = std::exchange(node, next);
-        }
-        return R{};
+        return inOrderTraverseImpl<R, const Node>(root, visitor, reverse);
     }
     template <typename Vis>
-    static auto traverse(const Derived* const root, const Vis& visitor, const bool reverse = false)
+    static auto traverse(const Derived* const root, const Vis& visitor, const bool reverse = false)  //
         -> std::enable_if_t<std::is_void<invoke_result<Vis, const Derived&>>::value>
     {
-        const Node* node = root;
-        const Node* prev = nullptr;
+        inOrderTraverseImpl<const Node>(root, visitor, reverse);
+    }
 
-        while (nullptr != node)
-        {
-            const Node* next = node->up;
-
-            if (prev == node->up)
-            {
-                // We came down to this node from `prev`.
-
-                if (auto* left = node->lr[reverse])
-                {
-                    next = left;
-                }
-                else
-                {
-                    visitor(*down(node));
-
-                    if (auto* right = node->lr[!reverse])
-                    {
-                        next = right;
-                    }
-                }
-            }
-            else if (prev == node->lr[reverse])
-            {
-                // We came up to this node from the left child.
-
-                visitor(*down(node));
-
-                if (auto* right = node->lr[!reverse])
-                {
-                    next = right;
-                }
-            }
-
-            prev = std::exchange(node, next);
-        }
+    template <typename Vis>
+    static void postOrderTraverse(Derived* const root, const Vis& visitor, const bool reverse = false)
+    {
+        postOrderTraverseImpl<Node>(root, visitor, reverse);
+    }
+    template <typename Vis>
+    static void postOrderTraverse(const Derived* const root, const Vis& visitor, const bool reverse = false)
+    {
+        postOrderTraverseImpl<const Node>(root, visitor, reverse);
     }
 
 private:
@@ -381,6 +226,14 @@ private:
     auto adjustBalance(const bool increment) noexcept -> Node*;
 
     auto retraceOnGrowth() noexcept -> Node*;
+
+    template <typename NodeT, typename DerivedT, typename Vis>
+    static void inOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse);
+    template <typename Result, typename NodeT, typename DerivedT, typename Vis>
+    static auto inOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse) -> Result;
+
+    template <typename NodeT, typename DerivedT, typename Vis>
+    static void postOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse);
 
     void unlink() noexcept
     {
@@ -653,6 +506,155 @@ auto Node<Derived>::retraceOnGrowth() noexcept -> Node*
     return (nullptr == p) ? c : nullptr;  // New root or nothing.
 }
 
+template <typename Derived>
+template <typename NodeT, typename DerivedT, typename Vis>
+void Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse)
+{
+    NodeT* node = root;
+    NodeT* prev = nullptr;
+
+    while (nullptr != node)
+    {
+        NodeT* next = node->up;
+
+        if (prev == node->up)
+        {
+            // We came down to this node from `prev`.
+
+            if (auto* left = node->lr[reverse])
+            {
+                next = left;
+            }
+            else
+            {
+                visitor(*down(node));
+
+                if (auto* right = node->lr[!reverse])
+                {
+                    next = right;
+                }
+            }
+        }
+        else if (prev == node->lr[reverse])
+        {
+            // We came up to this node from the left child.
+
+            visitor(*down(node));
+
+            if (auto* right = node->lr[!reverse])
+            {
+                next = right;
+            }
+        }
+
+        prev = std::exchange(node, next);
+    }
+}
+
+template <typename Derived>
+template <typename Result, typename NodeT, typename DerivedT, typename Vis>
+auto Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse) -> Result
+{
+    NodeT* node = root;
+    NodeT* prev = nullptr;
+
+    while (nullptr != node)
+    {
+        NodeT* next = node->up;
+
+        if (prev == node->up)
+        {
+            // We came down to this node from `prev`.
+
+            if (auto* left = node->lr[reverse])
+            {
+                next = left;
+            }
+            else
+            {
+                if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
+                {
+                    return t;
+                }
+
+                if (auto* right = node->lr[!reverse])
+                {
+                    next = right;
+                }
+            }
+        }
+        else if (prev == node->lr[reverse])
+        {
+            // We came up to this node from the left child.
+
+            if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
+            {
+                return t;
+            }
+
+            if (auto* right = node->lr[!reverse])
+            {
+                next = right;
+            }
+        }
+
+        prev = std::exchange(node, next);
+    }
+    return Result{};
+}
+
+template <typename Derived>
+template <typename NodeT, typename DerivedT, typename Vis>
+void Node<Derived>::postOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse)
+{
+    NodeT* node = root;
+    NodeT* prev = nullptr;
+
+    while (nullptr != node)
+    {
+        NodeT* next = node->up;
+
+        if (prev == node->up)
+        {
+            // We came down to this node from `prev`.
+
+            if (auto* left = node->lr[reverse])
+            {
+                next = left;
+            }
+            else if (auto* right = node->lr[!reverse])
+            {
+                next = right;
+            }
+            else
+            {
+                visitor(*down(node));
+            }
+        }
+        else if (prev == node->lr[reverse])
+        {
+            // We came up to this node from the left child.
+
+            if (auto* right = node->lr[!reverse])
+            {
+                next = right;
+            }
+            else
+            {
+                visitor(*down(node));
+            }
+        }
+        else
+        {
+            // We came up to this node from the right child.
+
+            visitor(*down(node));
+        }
+
+        prev = std::exchange(node, next);
+    }
+}
+
 /// This is a very simple convenience wrapper that is entirely optional to use.
 /// It simply keeps a single root pointer of the tree. The methods are mere wrappers over the static methods
 /// defined in the Node<> template class, such that the node pointer kept in the instance of this class is passed
@@ -736,6 +738,20 @@ public:
     {
         const TraversalIndicatorUpdater upd(*this);
         return NodeType::template traverse<Vis>(*this, visitor, reverse);
+    }
+
+    /// Wraps NodeType<>::postOrderTraverse().
+    template <typename Vis>
+    void postOrderTraverse(const Vis& visitor, const bool reverse = false)
+    {
+        const TraversalIndicatorUpdater upd(*this);
+        NodeType::template postOrderTraverse<Vis>(*this, visitor, reverse);
+    }
+    template <typename Vis>
+    void postOrderTraverse(const Vis& visitor, const bool reverse = false) const
+    {
+        const TraversalIndicatorUpdater upd(*this);
+        NodeType::template postOrderTraverse<Vis>(*this, visitor, reverse);
     }
 
     /// Normally these are not needed except if advanced introspection is desired.

--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -96,7 +96,7 @@ protected:
 
     /// Accessors for advanced tree introspection. Not needed for typical usage.
     bool isLinked() const noexcept { return nullptr != up; }
-    bool isRoot() const noexcept { return isLinked() && !up->isLinked(); }
+    bool isRoot() const noexcept { return isLinked() && (!up->isLinked()); }
     auto getParentNode() noexcept -> Derived* { return isRoot() ? nullptr : down(up); }
     auto getParentNode() const noexcept -> const Derived* { return isRoot() ? nullptr : down(up); }
     auto getChildNode(const bool right) noexcept -> Derived* { return down(lr[right]); }

--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -193,6 +193,20 @@ protected:
         inOrderTraverseImpl<const Node>(root, visitor, reverse);
     }
 
+    /// @breaf Post-order (or reverse-post-order) traversal of the tree.
+    ///
+    /// "Post" nature of the traversal guarantees that, once a node reference is passed to the visitor,
+    /// traversal won't use or reference this node anymore, so it is safe to modify the node in the visitor -
+    /// f.e. deallocate node's memory for an efficient "release whole tree" scenario. But the tree itself
+    /// shall not be modified while traversal is in progress, otherwise bad memory access will likely occur.
+    ///
+    /// @param root The root node of the tree to traverse.
+    /// @param visitor The callable object to invoke for each node. The visitor is invoked with a reference
+    ///                to each node as a POST-action call, AFTER visiting all of its children.
+    /// @param reverse If `false`, the traversal visits first "left" children, then "right" children.
+    ///                If `true`, the traversal is performed in reverse order ("right" first, then "left").
+    ///                In either case, the current node is visited last (hence the post-order).
+    ///
     template <typename Vis>
     static void postOrderTraverse(Derived* const root, const Vis& visitor, const bool reverse = false)
     {

--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -29,6 +29,7 @@
 #include <cstdint>
 #include <tuple>
 #include <type_traits>
+#include <utility>
 
 /// If CAVL is used in throughput-critical code, then it is recommended to disable assertion checks as they may
 /// be costly in terms of execution time.

--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -56,8 +56,9 @@ class Tree;
 /// The worst-case complexity of all operations is O(log n), unless specifically noted otherwise.
 /// Note that this class has no public members. The user type should re-export them if needed (usually it is not).
 /// The size of this type is 4x pointer size (16 bytes on a 32-bit platform).
+/// No Sonar cpp:S1448 b/c this is the main node entity without public members - maintainability is not a concern here.
 template <typename Derived>
-class Node
+class Node  // NOSONAR cpp:S1448
 {
     // Polyfill for C++17's std::invoke_result_t.
     template <typename F, typename... Args>
@@ -520,6 +521,7 @@ auto Node<Derived>::retraceOnGrowth() noexcept -> Node*
     return (nullptr == p) ? c : nullptr;  // New root or nothing.
 }
 
+// No Sonar cpp:S134 b/c this is the main in-order traversal tool - maintainability is not a concern here.
 template <typename Derived>
 template <typename NodeT, typename DerivedT, typename Vis>
 void Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse)
@@ -535,7 +537,7 @@ void Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor
         {
             // We came down to this node from `prev`.
 
-            if (auto* left = node->lr[reverse])
+            if (auto* const left = node->lr[reverse])
             {
                 next = left;
             }
@@ -543,7 +545,7 @@ void Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor
             {
                 visitor(*down(node));
 
-                if (auto* right = node->lr[!reverse])
+                if (auto* const right = node->lr[!reverse])  // NOSONAR cpp:S134
                 {
                     next = right;
                 }
@@ -555,16 +557,21 @@ void Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor
 
             visitor(*down(node));
 
-            if (auto* right = node->lr[!reverse])
+            if (auto* const right = node->lr[!reverse])
             {
                 next = right;
             }
+        }
+        else
+        {
+            // next has already been set to the parent node.
         }
 
         prev = std::exchange(node, next);
     }
 }
 
+// No Sonar cpp:S134 b/c this is the main in-order returning traversal tool - maintainability is not a concern here.
 template <typename Derived>
 template <typename Result, typename NodeT, typename DerivedT, typename Vis>
 auto Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor, const bool reverse) -> Result
@@ -580,18 +587,19 @@ auto Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor
         {
             // We came down to this node from `prev`.
 
-            if (auto* left = node->lr[reverse])
+            if (auto* const left = node->lr[reverse])
             {
                 next = left;
             }
             else
             {
-                if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
+                // NOLINTNEXTLINE(*-qualified-auto)
+                if (auto t = visitor(*down(node)))  // NOSONAR cpp:S134
                 {
                     return t;
                 }
 
-                if (auto* right = node->lr[!reverse])
+                if (auto* const right = node->lr[!reverse])  // NOSONAR cpp:S134
                 {
                     next = right;
                 }
@@ -606,10 +614,14 @@ auto Node<Derived>::inOrderTraverseImpl(DerivedT* const root, const Vis& visitor
                 return t;
             }
 
-            if (auto* right = node->lr[!reverse])
+            if (auto* const right = node->lr[!reverse])
             {
                 next = right;
             }
+        }
+        else
+        {
+            // next has already been set to the parent node.
         }
 
         prev = std::exchange(node, next);
@@ -632,11 +644,11 @@ void Node<Derived>::postOrderTraverseImpl(DerivedT* const root, const Vis& visit
         {
             // We came down to this node from `prev`.
 
-            if (auto* left = node->lr[reverse])
+            if (auto* const left = node->lr[reverse])
             {
                 next = left;
             }
-            else if (auto* right = node->lr[!reverse])
+            else if (auto* const right = node->lr[!reverse])
             {
                 next = right;
             }
@@ -649,7 +661,7 @@ void Node<Derived>::postOrderTraverseImpl(DerivedT* const root, const Vis& visit
         {
             // We came up to this node from the left child.
 
-            if (auto* right = node->lr[!reverse])
+            if (auto* const right = node->lr[!reverse])
             {
                 next = right;
             }

--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -95,12 +95,13 @@ protected:
     ~Node() = default;
 
     /// Accessors for advanced tree introspection. Not needed for typical usage.
-    auto getParentNode() noexcept -> Derived* { return down(up); }
-    auto getParentNode() const noexcept -> const Derived* { return down(up); }
+    bool isLinked() const noexcept { return nullptr != up; }
+    bool isRoot() const noexcept { return isLinked() && !up->isLinked(); }
+    auto getParentNode() noexcept -> Derived* { return isRoot() ? nullptr : down(up); }
+    auto getParentNode() const noexcept -> const Derived* { return isRoot() ? nullptr : down(up); }
     auto getChildNode(const bool right) noexcept -> Derived* { return down(lr[right]); }
     auto getChildNode(const bool right) const noexcept -> const Derived* { return down(lr[right]); }
     auto getBalanceFactor() const noexcept { return bf; }
-    auto getRootNodePtr() noexcept -> Derived** { return root_ptr; }
 
     /// Find a node for which the predicate returns zero, or nullptr if there is no such node or the tree is empty.
     /// The predicate is invoked with a single argument which is a constant reference to Derived.
@@ -109,55 +110,39 @@ protected:
     template <typename Pre>
     static auto search(Node* const root, const Pre& predicate) noexcept -> Derived*
     {
-        Derived*                         p   = down(root);
-        std::tuple<Derived*, bool> const out = search<Pre>(p, predicate, []() -> Derived* { return nullptr; });
-        CAVL_ASSERT(p == root);
-        return std::get<0>(out);
+        return searchImpl<Derived>(root, predicate);
     }
-
-    /// Same but const.
     template <typename Pre>
     static auto search(const Node* const root, const Pre& predicate) noexcept -> const Derived*
     {
-        const Node* out = nullptr;
-        const Node* n   = root;
-        while (n != nullptr)
-        {
-            const auto cmp = predicate(*down(n));
-            if (0 == cmp)
-            {
-                out = n;
-                break;
-            }
-            n = n->lr[cmp > 0];
-        }
-        return down(out);
+        return searchImpl<const Derived>(root, predicate);
     }
 
     /// This is like the regular search function except that if the node is missing, the factory will be invoked
     /// (without arguments) to construct a new one and insert it into the tree immediately.
-    /// The root node may be replaced in the process. If this method returns true, the tree is not modified;
+    /// The root node (inside the origin) may be replaced in the process.
+    /// If this method returns true, the tree is not modified;
     /// otherwise, the factory was (successfully!) invoked and a new node has been inserted into the tree.
     /// The factory does not need to be noexcept (may throw). It may also return nullptr to indicate intentional
     /// refusal to modify the tree, or f.e. in case of out of memory - result will be `(nullptr, true)` tuple.
     template <typename Pre, typename Fac>
-    static auto search(Derived*& root, const Pre& predicate, const Fac& factory) -> std::tuple<Derived*, bool>;
+    static auto search(Node& origin, const Pre& predicate, const Fac& factory) -> std::tuple<Derived*, bool>;
 
-    /// Remove the specified node from its tree. The root node may be replaced in the process.
+    /// Remove the specified node from its tree. The root node (inside the origin) may be replaced in the process.
     /// The function has no effect if the node pointer is nullptr.
     /// If the node is not in the tree, the behavior is undefined; it may create cycles in the tree which is deadly.
     /// It is safe to pass the result of search() directly as the second argument:
     ///     Node<T>::remove(root, Node<T>::search(root, search_predicate));
     ///
     /// No Sonar cpp:S6936 b/c the `remove` method name isolated inside `Node` type (doesn't conflict with C).
-    static void remove(Derived*& root, const Node* const node) noexcept;  // NOSONAR cpp:S6936
+    static void remove(Node& origin, const Node* const node) noexcept;  // NOSONAR cpp:S6936
 
     /// This is like the const overload of remove() except that the node pointers are invalidated afterward for safety.
     ///
     /// No Sonar cpp:S6936 b/c the `remove` method name isolated inside `Node` type (doesn't conflict with C).
-    static void remove(Derived*& root, Node* const node) noexcept  // NOSONAR cpp:S6936
+    static void remove(Node& origin, Node* const node) noexcept  // NOSONAR cpp:S6936
     {
-        remove(root, static_cast<const Node*>(node));
+        remove(origin, static_cast<const Node*>(node));
         if (nullptr != node)
         {
             node->unlink();
@@ -229,24 +214,18 @@ protected:
 private:
     void moveFrom(Node& other) noexcept
     {
-        root_ptr = other.root_ptr;
-        up       = other.up;
-        lr[0]    = other.lr[0];
-        lr[1]    = other.lr[1];
-        bf       = other.bf;
+        CAVL_ASSERT(!isLinked());  // Should not be part of any tree yet.
+
+        up    = other.up;
+        lr[0] = other.lr[0];
+        lr[1] = other.lr[1];
+        bf    = other.bf;
+        other.unlink();
 
         if (nullptr != up)
         {
             up->lr[up->lr[1] == &other] = this;
         }
-        else
-        {
-            if (nullptr != root_ptr)
-            {
-                *root_ptr = down(this);
-            }
-        }
-
         if (nullptr != lr[0])
         {
             lr[0]->up = this;
@@ -255,21 +234,17 @@ private:
         {
             lr[1]->up = this;
         }
-
-        other.unlink();
     }
 
     void rotate(const bool r) noexcept
     {
+        CAVL_ASSERT(isLinked());
         CAVL_ASSERT((lr[!r] != nullptr) && ((bf >= -1) && (bf <= +1)));
-        Node* const z = lr[!r];
-        if (up != nullptr)
-        {
-            up->lr[up->lr[1] == this] = z;
-        }
-        z->up  = up;
-        up     = z;
-        lr[!r] = z->lr[r];
+        Node* const z             = lr[!r];
+        up->lr[up->lr[1] == this] = z;
+        z->up                     = up;
+        up                        = z;
+        lr[!r]                    = z->lr[r];
         if (lr[!r] != nullptr)
         {
             lr[!r]->up = this;
@@ -289,13 +264,31 @@ private:
     template <typename NodeT, typename DerivedT, typename Vis>
     static void traversePostOrderImpl(DerivedT* const root, const Vis& visitor, const bool reverse);
 
+    template <typename DerivedT, typename NodeT, typename Pre>
+    static auto searchImpl(NodeT* const root, const Pre& predicate) noexcept -> DerivedT*
+    {
+        NodeT* n = root;
+        while (n != nullptr)
+        {
+            CAVL_ASSERT(nullptr != n->up);
+
+            DerivedT* const derived = down(n);
+            const auto      cmp     = predicate(*derived);
+            if (0 == cmp)
+            {
+                return derived;
+            }
+            n = n->lr[cmp > 0];
+        }
+        return nullptr;
+    }
+
     void unlink() noexcept
     {
-        root_ptr = nullptr;
-        up       = nullptr;
-        lr[0]    = nullptr;
-        lr[1]    = nullptr;
-        bf       = 0;
+        up    = nullptr;
+        lr[0] = nullptr;
+        lr[1] = nullptr;
+        bf    = 0;
     }
 
     static auto extremum(Node* const root, const bool maximum) noexcept -> Derived*
@@ -327,23 +320,27 @@ private:
 
     friend class Tree<Derived>;
 
-    Derived**            root_ptr = nullptr;
-    Node*                up       = nullptr;
+    Node*                up = nullptr;
     std::array<Node*, 2> lr{};
     std::int8_t          bf = 0;
 };
 
 template <typename Derived>
 template <typename Pre, typename Fac>
-auto Node<Derived>::search(Derived*& root, const Pre& predicate, const Fac& factory) -> std::tuple<Derived*, bool>
+auto Node<Derived>::search(Node& origin, const Pre& predicate, const Fac& factory) -> std::tuple<Derived*, bool>
 {
+    CAVL_ASSERT(!origin.isLinked());
+    Node*& root = origin.lr[0];
+
     Node* out = nullptr;
     Node* up  = root;
     Node* n   = root;
     bool  r   = false;
     while (n != nullptr)
     {
-        const auto cmp = predicate(static_cast<const Derived&>(*n));
+        CAVL_ASSERT(n->isLinked());
+
+        const auto cmp = predicate(*down(n));
         if (0 == cmp)
         {
             out = n;
@@ -360,26 +357,27 @@ auto Node<Derived>::search(Derived*& root, const Pre& predicate, const Fac& fact
     }
 
     out = factory();
+    CAVL_ASSERT(out != &origin);
     if (nullptr == out)
     {
         return std::make_tuple(nullptr, true);
     }
+    out->unlink();
 
     if (up != nullptr)
     {
         CAVL_ASSERT(up->lr[r] == nullptr);
         up->lr[r] = out;
+        out->up   = up;
     }
     else
     {
-        root = down(out);
+        root    = out;
+        out->up = &origin;
     }
-    out->unlink();
-    out->up       = up;
-    out->root_ptr = &root;
     if (Node* const rt = out->retraceOnGrowth())
     {
-        root = down(rt);
+        root = rt;
     }
     return std::make_tuple(down(out), false);
 }
@@ -387,12 +385,16 @@ auto Node<Derived>::search(Derived*& root, const Pre& predicate, const Fac& fact
 // No Sonar cpp:S6936 b/c the `remove` method name isolated inside `Node` type (doesn't conflict with C).
 // No Sonar cpp:S3776 cpp:S134 cpp:S5311 b/c this is the main removal tool - maintainability is not a concern here.
 template <typename Derived>
-void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // NOSONAR cpp:S6936 cpp:S3776
+void Node<Derived>::remove(Node& origin, const Node* const node) noexcept  // NOSONAR cpp:S6936 cpp:S3776
 {
+    CAVL_ASSERT(!origin.isLinked());
+    CAVL_ASSERT(node != &origin);  // The origin node is not part of the tree, so it cannot be removed.
+
     if (node != nullptr)
     {
+        Node*& root = origin.lr[0];
         CAVL_ASSERT(root != nullptr);  // Otherwise, the node would have to be nullptr.
-        CAVL_ASSERT((node->up != nullptr) || (node == root));
+        CAVL_ASSERT(node->isLinked());
         Node* p = nullptr;  // The lowest parent node that suffered a shortening of its subtree.
         bool  r = false;    // Which side of the above was shortened.
         // The first step is to update the topology and remember the node where to start the retracing from later.
@@ -406,7 +408,7 @@ void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // 
             re->lr[0]->up = re;
             if (re->up != node)
             {
-                p = re->up;  // Retracing starts with the ex-parent of our replacement node.
+                p = re->getParentNode();  // Retracing starts with the ex-parent of our replacement node.
                 CAVL_ASSERT(p->lr[0] == re);
                 p->lr[0] = re->lr[1];     // Reducing the height of the left subtree here.
                 if (p->lr[0] != nullptr)  // NOSONAR cpp:S134
@@ -423,13 +425,13 @@ void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // 
                 r = true;  // The right child of the replacement node remains the same, so we don't bother relinking it.
             }
             re->up = node->up;
-            if (re->up != nullptr)
+            if (!re->isRoot())
             {
                 re->up->lr[re->up->lr[1] == node] = re;  // Replace link in the parent of node.
             }
             else
             {
-                root = down(re);
+                root = re;
             }
         }
         else  // Either or both of the children are nullptr.
@@ -440,7 +442,7 @@ void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // 
             {
                 node->lr[rr]->up = p;
             }
-            if (p != nullptr)
+            if (!node->isRoot())
             {
                 r        = p->lr[1] == node;
                 p->lr[r] = node->lr[rr];
@@ -451,20 +453,20 @@ void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // 
             }
             else
             {
-                root = down(node->lr[rr]);
+                root = node->lr[rr];
             }
         }
         // Now that the topology is updated, perform the retracing to restore balance. We climb up adjusting the
         // balance factors until we reach the root or a parent whose balance factor becomes plus/minus one, which
         // means that that parent was able to absorb the balance delta; in other words, the height of the outer
         // subtree is unchanged, so upper balance factors shall be kept unchanged.
-        if (p != nullptr)
+        if (p != &origin)
         {
             Node* c = nullptr;
             for (;;)  // NOSONAR cpp:S5311
             {
                 c = p->adjustBalance(!r);
-                p = c->up;
+                p = c->getParentNode();
                 if ((c->bf != 0) || (nullptr == p))  // NOSONAR cpp:S134
                 {
                     // Reached the root or the height difference is absorbed by `c`.
@@ -475,7 +477,7 @@ void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // 
             if (nullptr == p)
             {
                 CAVL_ASSERT(c != nullptr);
-                root = down(c);
+                root = c;
             }
         }
     }
@@ -484,6 +486,7 @@ void Node<Derived>::remove(Derived*& root, const Node* const node) noexcept  // 
 template <typename Derived>
 auto Node<Derived>::adjustBalance(const bool increment) noexcept -> Node*
 {
+    CAVL_ASSERT(isLinked());
     CAVL_ASSERT(((bf >= -1) && (bf <= +1)));
     Node*      out    = this;
     const auto new_bf = static_cast<std::int8_t>(bf + (increment ? +1 : -1));
@@ -545,14 +548,14 @@ template <typename Derived>
 auto Node<Derived>::retraceOnGrowth() noexcept -> Node*
 {
     CAVL_ASSERT(0 == bf);
-    Node* c = this;      // Child
-    Node* p = this->up;  // Parent
+    Node* c = this;                   // Child
+    Node* p = this->getParentNode();  // Parent
     while (p != nullptr)
     {
         const bool r = p->lr[1] == c;  // c is the right child of parent
         CAVL_ASSERT(p->lr[r] == c);
         c = p->adjustBalance(r);
-        p = c->up;
+        p = c->getParentNode();
         if (0 == c->bf)
         {           // The height change of the subtree made this parent perfectly balanced (as all things should be),
             break;  // hence, the height of the outer subtree is unchanged, so upper balance factors are unchanged.
@@ -572,12 +575,11 @@ void Node<Derived>::traverseInOrderImpl(DerivedT* const root, const Vis& visitor
 
     while (nullptr != node)
     {
-        NodeT* next = node->up;
+        NodeT* next = node->getParentNode();
 
-        if (prev == node->up)
+        // Did we come down to this node from `prev`?
+        if (prev == next)
         {
-            // We came down to this node from `prev`.
-
             if (auto* const left = node->lr[reverse])
             {
                 next = left;
@@ -592,10 +594,9 @@ void Node<Derived>::traverseInOrderImpl(DerivedT* const root, const Vis& visitor
                 }
             }
         }
+        // Did we come up to this node from the left child?
         else if (prev == node->lr[reverse])
         {
-            // We came up to this node from the left child.
-
             visitor(*down(node));
 
             if (auto* const right = node->lr[!reverse])
@@ -622,12 +623,11 @@ auto Node<Derived>::traverseInOrderImpl(DerivedT* const root, const Vis& visitor
 
     while (nullptr != node)
     {
-        NodeT* next = node->up;
+        NodeT* next = node->getParentNode();
 
-        if (prev == node->up)
+        // Did we come down to this node from `prev`?
+        if (prev == next)
         {
-            // We came down to this node from `prev`.
-
             if (auto* const left = node->lr[reverse])
             {
                 next = left;
@@ -646,10 +646,9 @@ auto Node<Derived>::traverseInOrderImpl(DerivedT* const root, const Vis& visitor
                 }
             }
         }
+        // Did we come up to this node from the left child?
         else if (prev == node->lr[reverse])
         {
-            // We came up to this node from the left child.
-
             if (auto t = visitor(*down(node)))  // NOLINT(*-qualified-auto)
             {
                 return t;
@@ -679,12 +678,11 @@ void Node<Derived>::traversePostOrderImpl(DerivedT* const root, const Vis& visit
 
     while (nullptr != node)
     {
-        NodeT* next = node->up;
+        NodeT* next = node->getParentNode();
 
-        if (prev == node->up)
+        // Did we come down to this node from `prev`?
+        if (prev == next)
         {
-            // We came down to this node from `prev`.
-
             if (auto* const left = node->lr[reverse])
             {
                 next = left;
@@ -698,10 +696,9 @@ void Node<Derived>::traversePostOrderImpl(DerivedT* const root, const Vis& visit
                 visitor(*down(node));
             }
         }
+        // Did we come up to this node from the left child?
         else if (prev == node->lr[reverse])
         {
-            // We came up to this node from the left child.
-
             if (auto* const right = node->lr[!reverse])
             {
                 next = right;
@@ -711,10 +708,9 @@ void Node<Derived>::traversePostOrderImpl(DerivedT* const root, const Vis& visit
                 visitor(*down(node));
             }
         }
+        // We came up to this node from the right child.
         else
         {
-            // We came up to this node from the right child.
-
             visitor(*down(node));
         }
 
@@ -738,7 +734,6 @@ public:
     using NodeType    = ::cavl::Node<Derived>;
     using DerivedType = Derived;
 
-    explicit Tree(Derived* const root) : root_(root) {}
     Tree()  = default;
     ~Tree() = default;
 
@@ -747,16 +742,14 @@ public:
     auto operator=(const Tree&) -> Tree& = delete;
 
     /// Trees can be easily moved in constant time. This does not actually affect the tree itself, only this object.
-    Tree(Tree&& other) noexcept : root_(other.root_)
+    Tree(Tree&& other) noexcept : origin_node_{std::move(other.origin_node_)}
     {
         CAVL_ASSERT(!traversal_in_progress_);  // Cannot modify the tree while it is being traversed.
-        other.root_ = nullptr;
     }
     auto operator=(Tree&& other) noexcept -> Tree&
     {
         CAVL_ASSERT(!traversal_in_progress_);  // Cannot modify the tree while it is being traversed.
-        root_       = other.root_;
-        other.root_ = nullptr;
+        origin_node_ = std::move(other.origin_node_);
         return *this;
     }
 
@@ -764,18 +757,18 @@ public:
     template <typename Pre>
     auto search(const Pre& predicate) noexcept -> Derived*
     {
-        return NodeType::template search<Pre>(*this, predicate);
+        return NodeType::template search<Pre>(getRootNode(), predicate);
     }
     template <typename Pre>
     auto search(const Pre& predicate) const noexcept -> const Derived*
     {
-        return NodeType::template search<Pre>(*this, predicate);
+        return NodeType::template search<Pre>(getRootNode(), predicate);
     }
     template <typename Pre, typename Fac>
     auto search(const Pre& predicate, const Fac& factory) -> std::tuple<Derived*, bool>
     {
         CAVL_ASSERT(!traversal_in_progress_);  // Cannot modify the tree while it is being traversed.
-        return NodeType::template search<Pre, Fac>(root_, predicate, factory);
+        return NodeType::template search<Pre, Fac>(origin_node_, predicate, factory);
     }
 
     /// Wraps NodeType<>::remove().
@@ -784,7 +777,7 @@ public:
     void remove(NodeType* const node) noexcept  // NOSONAR cpp:S6936
     {
         CAVL_ASSERT(!traversal_in_progress_);  // Cannot modify the tree while it is being traversed.
-        NodeType::remove(root_, node);
+        NodeType::remove(origin_node_, node);
     }
 
     /// Wraps NodeType<>::min/max().
@@ -827,12 +820,12 @@ public:
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     operator Derived*() noexcept  // NOSONAR cpp:S1709
     {
-        return root_;
+        return getRootNode();
     }
     // NOLINTNEXTLINE(google-explicit-constructor,hicpp-explicit-conversions)
     operator const Derived*() const noexcept  // NOSONAR cpp:S1709
     {
-        return root_;
+        return getRootNode();
     }
 
     /// Access i-th element of the tree in linear time. Returns nullptr if the index is out of bounds.
@@ -858,7 +851,7 @@ public:
     }
 
     /// Unlike size(), this one is constant-complexity.
-    auto empty() const noexcept { return root_ == nullptr; }
+    auto empty() const noexcept { return getRootNode() == nullptr; }
 
 private:
     static_assert(!std::is_polymorphic<NodeType>::value,
@@ -886,7 +879,17 @@ private:
         const Tree& that;
     };
 
-    Derived* root_ = nullptr;
+    // root node pointer is stored in the origin_node_ left child.
+    auto getRootNode() noexcept -> Derived* { return origin_node_.getChildNode(false); }
+    auto getRootNode() const noexcept -> const Derived* { return origin_node_.getChildNode(false); }
+
+    // This a "fake" node, is not part of the tree itself, but it is used to store the root node pointer.
+    // The root node pointer is stored in the left child (see `getRootNode` methods).
+    // This is the only node which has the `up` pointer set to `nullptr`;
+    // all other "real" nodes always have non-null `up` pointer,
+    // including the root node whos `up` points to this origin node (see `isRoot` method).
+    Node<Derived> origin_node_{};
+
     // No Sonar cpp:S4963 b/c of implicit modification by the `TraversalIndicatorUpdater` RAII class,
     // even for `const` instance of the `Tree` class (hence the `mutable volatile` keywords).
     mutable volatile bool traversal_in_progress_ = false;  // NOSONAR cpp:S3687

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -156,7 +156,8 @@ template <typename T>
 void checkPostOrdering(const N<T>* const root, const std::vector<std::uint16_t>& expected, const bool reverse = false)
 {
     std::vector<std::uint16_t> order;
-    T::traversePostOrder(root, [&](const N<T>& nd) { order.push_back(nd.getValue()); }, reverse);
+    T::traversePostOrder(
+        root, [&](const N<T>& nd) { order.push_back(nd.getValue()); }, reverse);
     TEST_ASSERT_EQUAL(expected.size(), order.size());
     if (!order.empty())
     {

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -155,7 +155,8 @@ template <typename T>
 void checkPostOrdering(const N<T>* const root, const std::vector<std::uint16_t>& expected, const bool reverse = false)
 {
     std::vector<std::uint16_t> order;
-    T::postOrderTraverse(root, [&](const N<T>& nd) { order.push_back(nd.getValue()); }, reverse);
+    T::postOrderTraverse(
+        root, [&](const N<T>& nd) { order.push_back(nd.getValue()); }, reverse);
     TEST_ASSERT_EQUAL(expected.size(), order.size());
     if (!order.empty())
     {

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -49,10 +49,11 @@ class My : public cavl::Node<My>
 public:
     explicit My(const std::uint16_t v) : value(v) {}
     using Self = cavl::Node<My>;
+    using Self::isLinked;
+    using Self::isRoot;
     using Self::getChildNode;
     using Self::getParentNode;
     using Self::getBalanceFactor;
-    using Self::getRootNodePtr;
     using Self::search;
     using Self::remove;
     using Self::traverseInOrder;
@@ -271,7 +272,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
         const auto pred = [&](const N& v) { return t.at(i)->getValue() - v.getValue(); };
         TEST_ASSERT_NULL(tr.search(pred));
         TEST_ASSERT_NULL(static_cast<const TreeType&>(tr).search(pred));
+        TEST_ASSERT_FALSE(t[i]->isLinked());
         auto result = tr.search(pred, [&]() { return t[i]; });
+        TEST_ASSERT_TRUE(t[i]->isLinked());
         TEST_ASSERT_EQUAL(t[i], std::get<0>(result));
         TEST_ASSERT_FALSE(std::get<1>(result));
         TEST_ASSERT_EQUAL(t[i], tr.search(pred));
@@ -328,11 +331,18 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
                          {31, 29, 30, 27, 25, 26, 28, 23, 21, 22, 19, 17, 18, 20, 24, 15,
                           13, 14, 11, 9,  10, 12, 7,  5,  6,  3,  1,  2,  4,  8,  16},
                          true);
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[24]->isRoot());
 
     // MOVE 16, 18 & 23
     t[16] = node_mover(t[16]);
     t[18] = node_mover(t[18]);
     t[23] = node_mover(t[23]);
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[18]->isRoot());
+    TEST_ASSERT_TRUE(t[18]->isLinked());
+    TEST_ASSERT_FALSE(t[23]->isRoot());
+    TEST_ASSERT_TRUE(t[23]->isLinked());
 
     // REMOVE 24
     //                               16
@@ -357,6 +367,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(30, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[24]->isRoot());
+    TEST_ASSERT_FALSE(t[24]->isLinked());
     checkPostOrdering<N>(tr, {1,  3,  2,  5,  7,  6,  4,  9,  11, 10, 13, 15, 14, 12, 8,
                               17, 19, 18, 21, 23, 22, 20, 27, 26, 29, 31, 30, 28, 25, 16});
 
@@ -379,6 +392,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(29, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[25]->isRoot());
+    TEST_ASSERT_FALSE(t[25]->isLinked());
     checkPostOrdering<N>(tr, {1,  3,  2,  5,  7,  6,  4,  9,  11, 10, 13, 15, 14, 12, 8,
                               17, 19, 18, 21, 23, 22, 20, 27, 29, 31, 30, 28, 26, 16});
 
@@ -402,6 +418,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(28, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[26]->isRoot());
+    TEST_ASSERT_FALSE(t[26]->isLinked());
     checkPostOrdering<N>(tr, {1, 3,  2,  5,  7,  6,  4,  9,  11, 10, 13, 15, 14, 12,
                               8, 17, 19, 18, 21, 23, 22, 20, 29, 28, 31, 30, 27, 16});
 
@@ -424,6 +443,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(27, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[20]->isRoot());
+    TEST_ASSERT_FALSE(t[20]->isLinked());
     checkPostOrdering<N>(tr, {1, 3,  2,  5,  7,  6,  4,  9,  11, 10, 13, 15, 14, 12,
                               8, 17, 19, 18, 23, 22, 21, 29, 28, 31, 30, 27, 16});
 
@@ -446,6 +468,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(26, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[27]->isRoot());
+    TEST_ASSERT_FALSE(t[27]->isLinked());
     checkPostOrdering<N>(tr, {1,  3, 2,  5,  7,  6,  4,  9,  11, 10, 13, 15, 14,
                               12, 8, 17, 19, 18, 23, 22, 21, 29, 31, 30, 28, 16});
 
@@ -468,6 +493,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(25, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[28]->isRoot());
+    TEST_ASSERT_FALSE(t[28]->isLinked());
     checkPostOrdering<N>(tr,
                          {1, 3, 2, 5, 7, 6, 4, 9, 11, 10, 13, 15, 14, 12, 8, 17, 19, 18, 23, 22, 21, 31, 30, 29, 16});
 
@@ -504,6 +532,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(24, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[29]->isRoot());
+    TEST_ASSERT_FALSE(t[29]->isLinked());
     checkPostOrdering<N>(tr, {1, 3, 2, 5, 7, 6, 4, 9, 11, 10, 13, 15, 14, 12, 8, 17, 19, 18, 23, 22, 31, 30, 21, 16});
 
     // REMOVE 8
@@ -525,6 +556,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(23, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[8]->isRoot());
+    TEST_ASSERT_FALSE(t[8]->isLinked());
     checkPostOrdering<N>(tr, {1, 3, 2, 5, 7, 6, 4, 11, 10, 13, 15, 14, 12, 9, 17, 19, 18, 23, 22, 31, 30, 21, 16});
 
     // REMOVE 9
@@ -546,6 +580,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(22, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[9]->isRoot());
+    TEST_ASSERT_FALSE(t[9]->isLinked());
     checkPostOrdering<N>(tr, {1, 3, 2, 5, 7, 6, 4, 11, 13, 15, 14, 12, 10, 17, 19, 18, 23, 22, 31, 30, 21, 16});
 
     // REMOVE 1
@@ -566,6 +603,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(21, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[1]->isRoot());
+    TEST_ASSERT_FALSE(t[1]->isLinked());
     checkPostOrdering<N>(tr, {3, 2, 5, 7, 6, 4, 11, 13, 15, 14, 12, 10, 17, 19, 18, 23, 22, 31, 30, 21, 16});
 
     // REMOVE 16, the tree got new root.
@@ -590,6 +630,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(20, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[17]->isRoot());
+    TEST_ASSERT_FALSE(t[16]->isRoot());
+    TEST_ASSERT_FALSE(t[16]->isLinked());
     checkPostOrdering<N>(tr, {3, 2, 5, 7, 6, 4, 11, 13, 15, 14, 12, 10, 19, 18, 23, 22, 31, 30, 21, 17});
 
     // REMOVE 22, only has one child.
@@ -611,6 +654,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_NULL(findBrokenBalanceFactor<N>(tr));
     TEST_ASSERT_NULL(findBrokenAncestry<N>(tr));
     TEST_ASSERT_EQUAL(19, checkOrdering<N>(tr));
+    TEST_ASSERT_TRUE(t[17]->isRoot());
+    TEST_ASSERT_FALSE(t[22]->isRoot());
+    TEST_ASSERT_FALSE(t[22]->isLinked());
     checkPostOrdering<N>(tr, {3, 2, 5, 7, 6, 4, 11, 13, 15, 14, 12, 10, 19, 18, 23, 31, 30, 21, 17});
 
     // Print intermediate state for inspection. Be sure to compare it against the above diagram for extra paranoia.
@@ -665,6 +711,7 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(t.at(30), static_cast<const TreeType&>(tr).max());
     TEST_ASSERT_EQUAL(t[17], static_cast<N*>(tr));
     TEST_ASSERT_EQUAL(7, tr.size());
+    TEST_ASSERT_TRUE(t[17]->isRoot());
     checkPostOrdering<N>(tr, {4, 12, 10, 18, 30, 21, 17});
     checkPostOrdering<N>(tr, {30, 18, 21, 12, 4, 10, 17}, true);
 
@@ -692,6 +739,11 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(t.at(30), static_cast<const TreeType&>(tr).max());
     TEST_ASSERT_EQUAL(t[17], static_cast<N*>(tr));
     TEST_ASSERT_EQUAL(5, tr.size());
+    TEST_ASSERT_TRUE(t[17]->isRoot());
+    TEST_ASSERT_FALSE(t[10]->isRoot());
+    TEST_ASSERT_FALSE(t[10]->isLinked());
+    TEST_ASSERT_FALSE(t[21]->isRoot());
+    TEST_ASSERT_FALSE(t[21]->isLinked());
     checkPostOrdering<N>(tr, {4, 12, 18, 30, 17});
     checkPostOrdering<N>(tr, {18, 30, 4, 12, 17}, true);
 
@@ -715,6 +767,11 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(t.at(30), static_cast<const TreeType&>(tr).max());
     TEST_ASSERT_EQUAL(t[17], static_cast<N*>(tr));
     TEST_ASSERT_EQUAL(3, tr.size());
+    TEST_ASSERT_TRUE(t[17]->isRoot());
+    TEST_ASSERT_FALSE(t[12]->isRoot());
+    TEST_ASSERT_FALSE(t[12]->isLinked());
+    TEST_ASSERT_FALSE(t[18]->isRoot());
+    TEST_ASSERT_FALSE(t[18]->isLinked());
     checkPostOrdering<N>(tr, {4, 30, 17});
     checkPostOrdering<N>(tr, {30, 4, 17}, true);
 
@@ -736,6 +793,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(t.at(30), static_cast<const TreeType&>(tr).max());
     TEST_ASSERT_EQUAL(t[30], static_cast<N*>(tr));
     TEST_ASSERT_EQUAL(2, tr.size());
+    TEST_ASSERT_TRUE(t[30]->isRoot());
+    TEST_ASSERT_FALSE(t[17]->isRoot());
+    TEST_ASSERT_FALSE(t[17]->isLinked());
     checkPostOrdering<N>(tr, {4, 30});
     checkPostOrdering<N>(tr, {4, 30}, true);
 
@@ -754,6 +814,9 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(t.at(4), static_cast<const TreeType&>(tr).max());
     TEST_ASSERT_EQUAL(t[4], static_cast<N*>(tr));
     TEST_ASSERT_EQUAL(1, tr.size());
+    TEST_ASSERT_TRUE(t[4]->isRoot());
+    TEST_ASSERT_FALSE(t[30]->isRoot());
+    TEST_ASSERT_FALSE(t[30]->isLinked());
     checkPostOrdering<N>(tr, {4});
     checkPostOrdering<N>(tr, {4}, true);
 
@@ -767,6 +830,7 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(t.at(4), static_cast<N*>(tr3));  // Moved.
     TEST_ASSERT_NULL(static_cast<N*>(tr2));            // NOLINT use after move is intentional.
     TEST_ASSERT_EQUAL(1, tr3.size());
+    TEST_ASSERT_TRUE(t[4]->isRoot());
 
     // Try various methods on empty tree (including `const` one).
     //
@@ -780,6 +844,8 @@ void testManual(const std::function<N*(std::uint8_t)>& factory, const std::funct
     TEST_ASSERT_EQUAL(nullptr, tr4_const.min());
     TEST_ASSERT_EQUAL(nullptr, tr4_const.max());
     TEST_ASSERT_EQUAL(0, tr4_const.traverseInOrder([](const N&) { return 13; }));
+    TEST_ASSERT_FALSE(t[4]->isRoot());
+    TEST_ASSERT_FALSE(t[4]->isLinked());
     checkPostOrdering<N>(tr4_const, {});
     checkPostOrdering<N>(tr4_const, {}, true);
 
@@ -897,11 +963,8 @@ void testManualMy()
         },
         [](My* const old_node) {
             const auto value    = old_node->getValue();
-            My** const root_ptr = old_node->getRootNodePtr();
             My* const  new_node = new My(std::move(*old_node));  // NOLINT(*-owning-memory)
             TEST_ASSERT_EQUAL(value, new_node->getValue());
-            TEST_ASSERT_EQUAL(root_ptr, new_node->getRootNodePtr());
-            TEST_ASSERT_EQUAL(nullptr, old_node->getRootNodePtr());
             delete old_node;  // NOLINT(*-owning-memory)
             return new_node;
         });
@@ -912,6 +975,8 @@ class V : public cavl::Node<V>
 {
 public:
     using Self = cavl::Node<V>;
+    using Self::isLinked;
+    using Self::isRoot;
     using Self::getChildNode;
     using Self::getParentNode;
     using Self::getBalanceFactor;

--- a/c++/test.cpp
+++ b/c++/test.cpp
@@ -137,7 +137,7 @@ std::size_t checkReverseOrdering(const N<T>* const root)
             prev = &nd;
             size++;
 
-            // Fake `return` to cover other `traverse` overload (the returning one).
+            // Fake `return` to cover other `traverseInOrder` overload (the returning one).
             return false;
         },
         true /* reverse */);


### PR DESCRIPTION
- Fix for issue #13
- Added new `postOrderTraverse` method
- Reduced a bit code duplication at `const` vs `non-const` traversal algorythms - now single `traverseXxxOrderImpl` covers these 2 almost identical cases.
- Make nodes movable
- Rename `traverse` → `traverseInOrder`; added new `traversePostOrder`.