### PR TITLE
Arduino strings defines an F macro for flash strings.

### DIFF
--- a/c++/cavl.hpp
+++ b/c++/cavl.hpp
@@ -63,12 +63,12 @@ template <typename Derived>
 class Node  // NOSONAR cpp:S1448
 {
     // Polyfill for C++17's std::invoke_result_t.
-    template <typename F, typename... Args>
+    template <typename Function, typename... Args>
     using invoke_result =
 #if __cplusplus >= 201703L
-        std::invoke_result_t<F, Args...>;
+        std::invoke_result_t<Function, Args...>;
 #else
-        std::result_of_t<F(Args...)>;
+        std::result_of_t<Function(Args...)>;
 #endif
 
 public:


### PR DESCRIPTION
See also https://github.com/OpenCyphal-Garage/libcyphal/issues/410
